### PR TITLE
Fix Syntax, Missing IPCSock for notwin

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -6,9 +6,13 @@ import (
 )
 
 // Activity holds the data for discord rich presence
+// https://discord.com/developers/docs/events/gateway-events#activity-object-activity-types
 type Activity struct {
-	Details string `json:"details,omitempty"`
-	State   string `json:"state,omitempty"`
+	Type       int    `json:"type,omitempty"`
+	Name       string `json:"name,omitempty"`
+	StatusType int    `json:"status_display_type,omitempty"`
+	Details    string `json:"details,omitempty"`
+	State      string `json:"state,omitempty"`
 
 	Timestamps *Timestamps `json:"timestamps,omitempty"`
 	Assets     *Assets     `json:"assets,omitempty"`

--- a/ipc/ipc_notwin.go
+++ b/ipc/ipc_notwin.go
@@ -8,11 +8,11 @@ import (
 )
 
 // NewConnection opens the discord-ipc-0 unix socket
-func NewConnection() (*IPCSock, error) {
+func NewConnection() (*Socket, error) {
 	sock, err := net.DialTimeout("unix", GetIpcPath()+"/discord-ipc-0", time.Second*2)
 	if err != nil {
-		return nil err
+		return nil, err
 	}
 
-	return &IPCSock{sock}, nil
+	return &Socket{sock}, nil
 }


### PR DESCRIPTION
Wasn't able to get it running due to missing "," and incorrect Socket Variable name I assume. Got it working on Linux with these changes.